### PR TITLE
Move pry/yard/rdoc to development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.0
-  - 2.0.0
-  - 1.9.3
-  - jruby-19mode # JRuby in 1.9 mode
+  - 2.5.0
+  - 2.4.0
+  - 2.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,12 +9,10 @@ PATH
       heroku-api
       rack (~> 1.6.4)
       rack-ssl-enforcer
-      rdoc
       rollbar (~> 2.7.1)
       scrolls
       sinatra (~> 1.4.4)
       uuidtools
-      yard
 
 GEM
   remote: https://rubygems.org/
@@ -95,9 +93,11 @@ DEPENDENCIES
   guard-minitest
   pry
   rake
+  rdoc
   shotgun
   vault-test-tools
   vault-tools!
+  yard
   yard-sinatra
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       excon
       fernet (= 2.0.rc2)
       heroku-api
-      pry
       rack (~> 1.6.4)
       rack-ssl-enforcer
       rdoc
@@ -21,29 +20,29 @@ GEM
   remote: https://rubygems.org/
   specs:
     ansi (1.5.0)
-    aws-sdk (1.66.0)
-      aws-sdk-v1 (= 1.66.0)
-    aws-sdk-v1 (1.66.0)
+    aws-sdk (1.67.0)
+      aws-sdk-v1 (= 1.67.0)
+    aws-sdk-v1 (1.67.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4)
+      nokogiri (~> 1)
     coderay (1.1.1)
     dotenv (2.0.0)
-    excon (0.54.0)
+    excon (0.60.0)
     fernet (2.0.rc2)
       valcro (= 0.1)
     guard-compat (1.2.1)
     guard-minitest (2.4.4)
       guard-compat (~> 1.2)
       minitest (>= 3.0)
-    heroku-api (0.4.1)
+    heroku-api (0.4.3)
       excon (~> 0.45)
       multi_json (~> 1.8)
-    json (1.8.3)
+    json (1.8.6)
     logfmt (0.0.7)
     method_source (0.8.2)
     mini_portile (0.6.2)
     minitest (4.7.5)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pry (0.10.4)
@@ -51,26 +50,25 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
-    rack-protection (1.5.3)
+    rack-protection (1.5.4)
       rack
     rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
     rake (10.4.2)
-    rdoc (4.2.2)
-      json (~> 1.4)
+    rdoc (6.0.1)
     rollbar (2.7.1)
       multi_json
     rr (1.1.2)
     scrolls (0.3.8)
     shotgun (0.9.1)
       rack (>= 1.0)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
-    tilt (2.0.5)
+    tilt (2.0.8)
     turn (0.9.7)
       ansi
       minitest (~> 4)
@@ -95,6 +93,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv
   guard-minitest
+  pry
   rake
   shotgun
   vault-test-tools
@@ -102,4 +101,4 @@ DEPENDENCIES
   yard-sinatra
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'heroku-api'
   gem.add_dependency 'fernet', '2.0.rc2'
   gem.add_dependency 'rollbar', '~> 2.7.1'
-  gem.add_dependency 'rdoc'
-  gem.add_dependency 'yard'
   gem.add_dependency 'aws-sdk', '~> 1.0'
   gem.add_dependency 'excon'
   gem.add_dependency 'rack', '~> 1.6.4'
@@ -33,4 +31,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'rdoc'
+  gem.add_development_dependency 'yard'
 end

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'excon'
   gem.add_dependency 'rack', '~> 1.6.4'
   gem.add_dependency 'coderay'
-  gem.add_dependency 'pry'
 
   gem.add_development_dependency 'dotenv'
+  gem.add_development_dependency 'pry'
 end


### PR DESCRIPTION
This also updates the ruby versions we test against as I don't think we have any apps running EOL'd ruby versions 🙀 