### PR TITLE
Upgrade Scrolls to 0.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       rack (~> 1.6.4)
       rack-ssl-enforcer
       rollbar (~> 2.7.1)
-      scrolls
+      scrolls (~> 0.9)
       sinatra (~> 1.4.4)
       uuidtools
       zipkin-tracer (~> 0.27)
@@ -64,7 +64,7 @@ GEM
     rollbar (2.7.1)
       multi_json
     rr (1.1.2)
-    scrolls (0.3.8)
+    scrolls (0.9.0)
     shotgun (0.9.1)
       rack (>= 1.0)
     sinatra (1.4.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vault-tools (0.6.0)
+    vault-tools (0.6.1)
       aws-sdk (~> 1.0)
       coderay
       excon

--- a/lib/vault-tools.rb
+++ b/lib/vault-tools.rb
@@ -66,6 +66,14 @@ module Vault
     end
   end
 
+  def self.init_scrolls
+    # Scrolls 0.9.0+ requires an init
+    Scrolls.init(
+      global_context: {app: Vault::Config.app_name},
+      time_unit: 'milliseconds'
+    )
+  end
+
   # all in one go
   def self.setup
     self.require
@@ -74,6 +82,7 @@ module Vault
     self.hack_time_class
     self.override_global_config
     self.load_shared_config
+    self.init_scrolls
     Tracing.configure
   end
 end

--- a/lib/vault-tools/version.rb
+++ b/lib/vault-tools/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Tools
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep('^(test|spec|features)/')
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'scrolls'
+  gem.add_dependency 'scrolls', '~> 0.9'
   gem.add_dependency 'sinatra', '~> 1.4.4'
   gem.add_dependency 'uuidtools'
   gem.add_dependency 'rack-ssl-enforcer'


### PR DESCRIPTION
Updating vault-tools in other repos is causing an issue where scrolls has a breaking API change and requires an init call