### PR TITLE
Shortcut tracing sidekiq if tracer is falsey

### DIFF
--- a/lib/vault-tools/tracing.rb
+++ b/lib/vault-tools/tracing.rb
@@ -100,7 +100,7 @@ module Vault
         end
       end
     end
-    private_class_method :setup_excon
+    private_class_method :setup_sidekiq
 
     # Checks to see if Excon is defined and if the Zipkin middleware has already
     # been inserted.

--- a/lib/vault-tools/tracing/sidekiq_client.rb
+++ b/lib/vault-tools/tracing/sidekiq_client.rb
@@ -17,7 +17,7 @@ module Vault
         trace_id = ::ZipkinTracer::TraceGenerator.new.next_trace_id
         ::ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
           job["zipkin_trace_information"] = trace_information(trace_id)
-          if trace_id.sampled?
+          if trace_id.sampled? && ::Trace.tracer
             ::Trace.tracer.with_new_span(trace_id, "sidekiq") do |span|
               local_endpoint = Trace.default_endpoint
               klass = job["wrapped".freeze] || worker_class

--- a/test/tracing_test.rb
+++ b/test/tracing_test.rb
@@ -67,7 +67,7 @@ class TracingTest < Vault::TestCase
     sidekiq_mock = Minitest::Mock.new
     sidekiq_mock.expect :configure_server, true
     sidekiq_mock.expect :configure_client, true
-    Vault::Tracing.setup_sidekiq(sidekiq_mock)
+    Vault::Tracing.send(:setup_sidekiq, sidekiq_mock)
     assert sidekiq_mock.verify,
       'Vault::Tracing.setup_sidekiq should call ::configure_server, and ::configure_client on Sidekiq'
   end


### PR DESCRIPTION
Apparently the Trace.tracer can be nil somehow

Stacktrace:

```
2018-04-04T13:34:31.427234+00:00 app[run.3928]: /app/vendor/bundle/ruby/2.3.0/gems/vault-tools-0.6.4/lib/vault-tools/tracing/sidekiq_client.rb:21:in `block in call': undefined method `with_new_span' for nil:NilClass (NoMethodError)
2018-04-04T13:34:31.427238+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/zipkin-tracer-0.27.2.1/lib/zipkin-tracer/trace_container.rb:8:in `with_trace_id'
2018-04-04T13:34:31.427239+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/vault-tools-0.6.4/lib/vault-tools/tracing/sidekiq_client.rb:18:in `call'
2018-04-04T13:34:31.427242+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
2018-04-04T13:34:31.427244+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-pro-3.5.2/lib/sidekiq/batch/middleware.rb:15:in `call'
2018-04-04T13:34:31.427246+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
2018-04-04T13:34:31.427248+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:133:in `invoke'
2018-04-04T13:34:31.427251+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/client.rb:209:in `process_single'
2018-04-04T13:34:31.427253+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/client.rb:68:in `push'
2018-04-04T13:34:31.427255+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/worker.rb:142:in `client_push'
2018-04-04T13:34:31.427257+00:00 app[run.3928]:     from /app/vendor/bundle/ruby/2.3.0/gems/sidekiq-5.0.4/lib/sidekiq/worker.rb:86:in `perform_async'
2018-04-04T13:34:31.427260+00:00 app[run.3928]:     from /app/bin/build_all_invoices:92:in `block in <main>'
2018-04-04T13:34:31.427262+00:00 app[run.3928]:     from /app/bin/build_all_invoices:76:in `each'
2018-04-04T13:34:31.427265+00:00 app[run.3928]:     from /app/bin/build_all_invoices:76:in `<main>'`'``'```````````
```