### PR TITLE
Remove zipkin sidekiq tracing for now until I can get it working

### DIFF
--- a/test/tracing_test.rb
+++ b/test/tracing_test.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'sidekiq'
 
 class TracingTest < Vault::TestCase
   # Anonymous Web Frontend
@@ -56,20 +55,9 @@ class TracingTest < Vault::TestCase
   end
 
   def test_excon
-    enable
     Vault::Tracing.configure
     assert Excon.defaults[:middlewares].include?(ZipkinTracer::ExconHandler),
       "Vault::Tracing.setup_excon should add ZipkinTracer::ExconHandler to excon's middleware"
-  end
-
-  def test_sidekiq
-    enable
-    sidekiq_mock = Minitest::Mock.new
-    sidekiq_mock.expect :configure_server, true
-    sidekiq_mock.expect :configure_client, true
-    Vault::Tracing.setup_sidekiq(sidekiq_mock)
-    assert sidekiq_mock.verify,
-      'Vault::Tracing.setup_sidekiq should call ::configure_server, and ::configure_client on Sidekiq'
   end
 
   def test_enabled_true

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -33,6 +33,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'dotenv'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rdoc'
-  gem.add_development_dependency 'sidekiq'
   gem.add_development_dependency 'yard'
 end


### PR DESCRIPTION
This removes the sidekiq tracing for zipkin since a bug in my code is killing bg workers. I cannot seem to get the README version of the gem's sidekiq tracing working. So for now, let's rip it out until we know we will need it