### PR TITLE
Add Config.fetch to enable fallback config var values

### DIFF
--- a/lib/vault-tools/config.rb
+++ b/lib/vault-tools/config.rb
@@ -199,5 +199,15 @@ module Vault
     def self.sidekiq_concurrency
       int('SIDEKIQ_CONCURRENCY') || 25
     end
+
+    # Return a fallback value if a given Config var is not set
+    #
+    # @param name [String] The name of the environment variable.
+    # @param fallback [String] The value to return if there is no value for the
+    # name param.
+    # @return [String] Either the set Config var value or the fallback value
+    def self.fetch(name, fallback)
+      self[name].nil? ? fallback : self[name]
+    end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -219,4 +219,19 @@ class ConfigTest < Vault::TestCase
     set_env 'SIDEKIQ_CONCURRENCY', '10'
     assert_equal(10, Config.sidekiq_concurrency)
   end
+
+  # Confg.fetch(:some_var, 'whatever') will fallback to 'whatever' if SOME_VAR
+  # is not defined.
+  def test_fetch_allows_fallback_value
+    assert_equal('bar', Config.fetch(:some_var, 'bar'))
+    set_env 'SOME_VAR', 'foo'
+    assert_equal('foo', Config.fetch(:some_var, 'bar'))
+  end
+
+  # Confg.fetch(:some_var, 'whatever') will allow SOME_VAR to be false
+  def test_fetch_allows_value_to_be_false
+    assert_equal('bar', Config.fetch(:some_var, 'bar'))
+    set_env 'SOME_VAR', 'false'
+    assert_equal('false', Config.fetch(:some_var, 'bar'))
+  end
 end


### PR DESCRIPTION
example:
```ruby
Config[:some_var] # => nil
Config.fetch(:some_var, 'some_fallback_value') #=> 'some_fallback_value'
```

This more closely mimics the behavior of `Hash`