### PR TITLE
Bump gems to address security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,12 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rake'
+  gem 'rake', '~> 10.4'
   gem 'shotgun', '~> 0.9.2'
   gem 'yard-sinatra'
 end
 
 group :test do
-  gem 'vault-test-tools', '0.4'
   gem 'guard-minitest'
+  gem 'vault-test-tools', '~> 0.4.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gemspec
 
 group :development do
   gem 'rake'
-  gem 'shotgun'
+  gem 'shotgun', '~> 0.9.2'
   gem 'yard-sinatra'
 end
 
 group :test do
-  gem 'vault-test-tools'
+  gem 'vault-test-tools', '0.4'
   gem 'guard-minitest'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,17 @@
 PATH
+  remote: ../vault-test-tools
+  specs:
+    vault-test-tools (0.4)
+      guard-minitest
+      logfmt
+      minitest (~> 4.7.4)
+      nokogiri
+      rack-test (~> 1.1.0)
+      rr
+      scrolls (= 0.9)
+      turn
+
+PATH
   remote: .
   specs:
     vault-tools (1.0.0)
@@ -7,11 +20,11 @@ PATH
       excon
       fernet (= 2.0.rc2)
       heroku-api
-      rack (~> 1.6.4)
+      rack (~> 2.0)
       rack-ssl-enforcer
       rollbar (~> 2.7.1)
       scrolls (~> 0.9)
-      sinatra (~> 1.4.4)
+      sinatra (~> 2.0.4)
       uuidtools
       zipkin-tracer (~> 0.27)
 
@@ -25,10 +38,10 @@ GEM
       json (~> 1.4)
       nokogiri (~> 1)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.2)
     dotenv (2.0.0)
     excon (0.62.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     fernet (2.0.rc2)
       valcro (= 0.1)
@@ -42,35 +55,37 @@ GEM
       excon (~> 0.45)
       multi_json (~> 1.8)
     json (1.8.6)
-    logfmt (0.0.7)
+    logfmt (0.0.8)
     method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (4.7.5)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.2)
+    mustermann (1.0.3)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (1.6.4)
-    rack-protection (1.5.5)
+    rack (2.0.6)
+    rack-protection (2.0.4)
       rack
     rack-ssl-enforcer (0.2.9)
-    rack-test (0.6.3)
-      rack (>= 1.0)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rake (10.4.2)
     rdoc (6.0.1)
     rollbar (2.7.1)
       multi_json
-    rr (1.1.2)
+    rr (1.2.1)
     scrolls (0.9.0)
-    shotgun (0.9.1)
+    shotgun (0.9.2)
       rack (>= 1.0)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+    sinatra (2.0.4)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.4)
+      tilt (~> 2.0)
     sucker_punch (2.1.1)
       concurrent-ruby (~> 1.0)
     thrift (0.9.3.0)
@@ -80,19 +95,10 @@ GEM
       minitest (~> 4)
     uuidtools (2.1.5)
     valcro (0.1)
-    vault-test-tools (0.3.9)
-      guard-minitest
-      logfmt
-      minitest (~> 4.7.4)
-      nokogiri
-      rack-test
-      rr
-      scrolls
-      turn
     yard (0.9.12)
     yard-sinatra (1.0.0)
       yard (~> 0.7)
-    zipkin-tracer (0.28.0)
+    zipkin-tracer (0.29.0)
       faraday (~> 0.8)
       finagle-thrift (~> 1.4.2)
       rack (>= 1.0)
@@ -107,8 +113,8 @@ DEPENDENCIES
   pry
   rake
   rdoc
-  shotgun
-  vault-test-tools
+  shotgun (~> 0.9.2)
+  vault-test-tools (= 0.4)!
   vault-tools!
   yard
   yard-sinatra

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,7 @@
 PATH
-  remote: ../vault-test-tools
-  specs:
-    vault-test-tools (0.4)
-      guard-minitest
-      logfmt
-      minitest (~> 4.7.4)
-      nokogiri
-      rack-test (~> 1.1.0)
-      rr
-      scrolls (= 0.9)
-      turn
-
-PATH
   remote: .
   specs:
-    vault-tools (1.0.0)
+    vault-tools (1.0.1)
       aws-sdk (~> 1.0)
       coderay
       excon
@@ -31,15 +18,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ansi (1.5.0)
     aws-sdk (1.67.0)
       aws-sdk-v1 (= 1.67.0)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
     coderay (1.1.2)
-    concurrent-ruby (1.1.2)
-    dotenv (2.0.0)
+    concurrent-ruby (1.1.3)
+    dotenv (2.5.0)
     excon (0.62.0)
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
@@ -48,7 +34,7 @@ GEM
     finagle-thrift (1.4.2)
       thrift (~> 0.9.3)
     guard-compat (1.2.1)
-    guard-minitest (2.4.4)
+    guard-minitest (2.4.6)
       guard-compat (~> 1.2)
       minitest (>= 3.0)
     heroku-api (0.4.3)
@@ -56,15 +42,15 @@ GEM
       multi_json (~> 1.8)
     json (1.8.6)
     logfmt (0.0.8)
-    method_source (0.9.0)
+    method_source (0.9.2)
     mini_portile2 (2.3.0)
-    minitest (4.7.5)
+    minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.3)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (2.0.6)
@@ -73,8 +59,8 @@ GEM
     rack-ssl-enforcer (0.2.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (10.4.2)
-    rdoc (6.0.1)
+    rake (10.5.0)
+    rdoc (6.0.4)
     rollbar (2.7.1)
       multi_json
     rr (1.2.1)
@@ -90,15 +76,19 @@ GEM
       concurrent-ruby (~> 1.0)
     thrift (0.9.3.0)
     tilt (2.0.8)
-    turn (0.9.7)
-      ansi
-      minitest (~> 4)
     uuidtools (2.1.5)
     valcro (0.1)
-    yard (0.9.12)
+    vault-test-tools (0.4.2)
+      logfmt
+      minitest (~> 5.11)
+      nokogiri
+      rack-test (~> 1.1)
+      rr
+      scrolls (= 0.9)
+    yard (0.9.16)
     yard-sinatra (1.0.0)
       yard (~> 0.7)
-    zipkin-tracer (0.29.0)
+    zipkin-tracer (0.29.1)
       faraday (~> 0.8)
       finagle-thrift (~> 1.4.2)
       rack (>= 1.0)
@@ -111,13 +101,13 @@ DEPENDENCIES
   dotenv
   guard-minitest
   pry
-  rake
+  rake (~> 10.4)
   rdoc
   shotgun (~> 0.9.2)
-  vault-test-tools (= 0.4)!
+  vault-test-tools (~> 0.4.2)
   vault-tools!
   yard
   yard-sinatra
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/lib/vault-tools/version.rb
+++ b/lib/vault-tools/version.rb
@@ -2,6 +2,6 @@
 
 module Vault
   module Tools
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -114,14 +114,14 @@ class ConfigTest < Vault::TestCase
   # variable.
   def test_app_name
     set_env 'APP_NAME', "my-app"
-    Config.app_name.must_equal 'my-app'
+    assert_equal(Config.app_name, 'my-app')
   end
 
   # Config.app_deploy returns the value of the APP_DEPLOY environment
   # variable.
   def test_app_deploy
     set_env 'APP_DEPLOY', "test"
-    Config.app_deploy.must_equal 'test'
+    assert_equal(Config.app_deploy, 'test')
   end
 
   # Config.port raises a RuntimeError if no `PORT` environment variable

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'scrolls', '~> 0.9'
-  gem.add_dependency 'sinatra', '~> 1.4.4'
+  gem.add_dependency 'sinatra', '~> 2.0.4'
   gem.add_dependency 'uuidtools'
   gem.add_dependency 'rack-ssl-enforcer'
   gem.add_dependency 'heroku-api'
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rollbar', '~> 2.7.1'
   gem.add_dependency 'aws-sdk', '~> 1.0'
   gem.add_dependency 'excon'
-  gem.add_dependency 'rack', '~> 1.6.4'
+  gem.add_dependency 'rack', '~> 2.0'
   gem.add_dependency 'coderay'
   gem.add_dependency 'zipkin-tracer', '~> 0.27'
 


### PR DESCRIPTION
When launching the new vault-enterprise-usage service, Snyk showed a number of vulnerabilities that could only be addressed by bumping Sinatra and Rack inside the vault-tools gem. 
https://app.snyk.io/org/heroku-default/project/f3439102-8cfb-4ef6-bcae-43364114b1cf

This PR will show failing tests because it depends on https://github.com/heroku/vault-test-tools/pull/10 being released to RubyGems first but it is passing locally.

`vault-test-tools` also needed to be updated in order to update this gem, since this gem includes `vault-test-tools` and they have shared dependencies that could not be resolved otherwise.