### PR TITLE
adds code to address issues with puma upgrade

### DIFF
--- a/lib/vault-tools/web.rb
+++ b/lib/vault-tools/web.rb
@@ -100,6 +100,13 @@ module Vault
     # Start timing the request.
     before do
       @start_request = Time.now
+      # if client sends content_type: application/json which no longer works
+      # https://github.com/puma/puma/compare/4.3.1...4.3.5#commitcomment-39478516
+      #
+      # fixing this here so that we do not break all client users at once
+      if request.env["CONTENT_TYPE"].nil? && request.env["HTTP_CONTENT_TYPE"]
+        request.env["CONTENT_TYPE"] = request.env["HTTP_CONTENT_TYPE"]
+      end
     end
 
     # Log details about the request including how long it took.


### PR DESCRIPTION
In order to comply with needed security patches in vault-landp we needed to add some logic in the before filter to match other applications in web-services who also upgraded.   The basic issue is that a puma upgraded changes how the header "Content-Type" is handled.

See:
https://github.com/heroku/limacologist/pull/233/files#diff-731f15c96e4377eb71993b01864822a2

https://github.com/heroku/eventbus-pub/pull/72/files#diff-f17fef1ffd3421b7da91e167094b6abbR49-R53

Related:
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008D2IyIAK/view