### PR TITLE
remove travis and add circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker: 
-      - image: circleci/ruby:2.7.1
+      - image: circleci/ruby:2.5.3
     steps:
       - checkout
       - run: export BUNDLE_GEMFILE=$PWD/Gemfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+jobs:
+  build:
+    docker: 
+      - image: circleci/ruby:2.7.1
+    steps:
+      - checkout
+      - run: export BUNDLE_GEMFILE=$PWD/Gemfile
+      - run: ruby --version
+      - run: gem update --system
+      - run: gem install bundler -v '< 2'
+      - run: bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
+      - run: bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 jobs:
-  build:
-    docker: 
+  rubyVersion1:
+    docker:
       - image: circleci/ruby:2.5.3
     steps:
       - checkout
@@ -12,3 +12,21 @@ jobs:
       - run: gem install bundler -v '< 2'
       - run: bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
       - run: bundle exec rake
+
+  rubyVersion2:
+    docker:
+      - image: circleci/ruby:2.6.0
+    steps:
+      - checkout
+      - run: export BUNDLE_GEMFILE=$PWD/Gemfile
+      - run: ruby --version
+      - run: gem update --system
+      - run: gem install bundler -v '< 2'
+      - run: bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
+      - run: bundle exec rake
+
+workflows:
+  run-jobs:
+    jobs:
+      - rubyVersion1
+      - rubyVersion2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.0
-  - 2.5.3
-before_install:
-  - gem install bundler -v '< 2'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Tools is the English word for ツール.  Tooling for the Heroku Vault
 team to enable faster bootstrapping for Ruby projects.
 
-[![Build Status](https://travis-ci.org/heroku/vault-tools.png?branch=master)](https://travis-ci.org/heroku/vault-tools)
+[![CircleCI](https://circleci.com/gh/heroku/vault-tools/tree/master.svg?style=shield&circle-token=39ec638ab252a4440ca919f9b09dc258b4459c58)](_https://circleci.com/gh/heroku/vault-tools/tree/master_)
 
 ## Installation
 


### PR DESCRIPTION
This removes the travis file from the repository and adds circle ci configuration to vault-tools since we no longer use travis.

[Gus Card](https://gus.my.salesforce.com/a07EE000000aASJYA2)