### PR TITLE
upgrade ruby to 2.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2.1
 
 jobs:
-  rubyVersion1:
+  build:
     docker:
-      - image: circleci/ruby:2.5.3
-    steps:
+      - image: circleci/ruby:2.7.1
+    
+      steps:
       - checkout
       - run: export BUNDLE_GEMFILE=$PWD/Gemfile
       - run: ruby --version
@@ -12,21 +13,3 @@ jobs:
       - run: gem install bundler -v '< 2'
       - run: bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
       - run: bundle exec rake
-
-  rubyVersion2:
-    docker:
-      - image: circleci/ruby:2.6.0
-    steps:
-      - checkout
-      - run: export BUNDLE_GEMFILE=$PWD/Gemfile
-      - run: ruby --version
-      - run: gem update --system
-      - run: gem install bundler -v '< 2'
-      - run: bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
-      - run: bundle exec rake
-
-workflows:
-  run-jobs:
-    jobs:
-      - rubyVersion1
-      - rubyVersion2

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development do
 end
 
 group :test do
-  gem 'guard-minitest'
   gem 'minitest-around'
-  gem 'vault-test-tools', '~> 1.0.0'
+  gem 'vault-test-tools', '~> 1.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,59 +16,57 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.1.0)
-    aws-partitions (1.332.0)
-    aws-sdk-core (3.100.0)
+    aws-eventstream (1.1.1)
+    aws-partitions (1.490.0)
+    aws-sdk-core (3.119.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.34.1)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-kms (1.46.0)
+      aws-sdk-core (~> 3, >= 3.119.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.69.1)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-s3 (1.99.0)
+      aws-sdk-core (~> 3, >= 3.119.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.0)
+    aws-sigv4 (1.2.4)
       aws-eventstream (~> 1, >= 1.0.2)
-    coderay (1.1.2)
-    dotenv (2.5.0)
-    excon (0.75.0)
+    coderay (1.1.3)
+    dotenv (2.7.6)
+    excon (0.85.0)
     fernet (2.0)
       valcro (= 0.1)
-    guard-compat (1.2.1)
-    guard-minitest (2.4.6)
-      guard-compat (~> 1.2)
-      minitest (>= 3.0)
     jmespath (1.4.0)
-    logfmt (0.0.8)
-    method_source (0.9.2)
-    mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    logfmt (0.0.9)
+    method_source (1.0.0)
+    mini_portile2 (2.6.1)
+    minitest (5.14.4)
     minitest-around (0.5.0)
       minitest (~> 5.0)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rack (2.0.6)
+    nokogiri (1.12.3)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.5.2)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     rack-ssl-enforcer (0.2.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (13.0.1)
-    rdoc (6.1.1)
+    rake (13.0.6)
+    rdoc (6.3.2)
     rollbar (2.18.2)
       multi_json
     rr (1.2.1)
-    ruby2_keywords (0.0.2)
-    scrolls (0.9.0)
+    ruby2_keywords (0.0.5)
+    scrolls (0.9.1)
     shotgun (0.9.2)
       rack (>= 1.0)
     sinatra (2.0.8.1)
@@ -77,16 +75,16 @@ GEM
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     tilt (2.0.10)
-    uuidtools (2.1.5)
+    uuidtools (2.2.0)
     valcro (0.1)
-    vault-test-tools (1.0.0)
+    vault-test-tools (1.1.0)
       logfmt
       minitest (~> 5.11)
       nokogiri
       rack-test (~> 1.1)
-      rr
-      scrolls (= 0.9)
-    yard (0.9.25)
+      rr (~> 1.2)
+      scrolls
+    yard (0.9.26)
     yard-sinatra (1.0.0)
       yard (~> 0.7)
 
@@ -95,16 +93,15 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  guard-minitest
   minitest-around
   pry
   rake (~> 13.0)
   rdoc
   shotgun (~> 0.9.2)
-  vault-test-tools (~> 1.0.0)
+  vault-test-tools (~> 1.1.0)
   vault-tools!
   yard
   yard-sinatra
 
 BUNDLED WITH
-   1.17.3
+   2.2.26

--- a/lib/vault-tools/pipeline.rb
+++ b/lib/vault-tools/pipeline.rb
@@ -16,7 +16,7 @@ module Vault
   class Pipeline
     def self.use(*args)
       @filters ||= []
-      @filters.push *args
+      @filters.push(*args)
     end
 
     def self.filters

--- a/lib/vault-tools/product.rb
+++ b/lib/vault-tools/product.rb
@@ -10,7 +10,7 @@ module Vault
     #   ':' characters.
     # @return [String] A v5 UUID that uniquely represents the product.
     def self.name_to_uuid(name)
-      unless name =~ /[a-z,0-9,:]+/
+      unless name =~ /[a-z,0-9]+/
         raise "Product name empty or contains illegal characters."
       end
       url = "https://vault.heroku.com/products/#{name}"

--- a/lib/vault-tools/web.rb
+++ b/lib/vault-tools/web.rb
@@ -53,7 +53,7 @@ module Vault
       # protect! is used
       %w{get put post delete head options path link unlink}.each do |meth|
         define_method "#{meth}_unprotected".to_sym do |path, opts = {}, &block|
-          pattern = compile!(meth.upcase, path, block, opts).first
+          pattern = compile!(meth.upcase, path, block, **opts).first
           set :unprotected_paths, settings.unprotected_paths + [pattern]
           if meth.downcase == 'get'
             conditions = @conditions.dup

--- a/test/log_test.rb
+++ b/test/log_test.rb
@@ -116,6 +116,6 @@ class LogTest < Vault::TestCase
     assert_equal 'true', logged_data['A']
     assert_equal 'true', logged_data['B']
     assert_equal 'test-deploy', logged_data['source']
-    assert_match /\d/, logged_data['elapsed']
+    assert_match (/\d/), logged_data['elapsed']
   end
 end

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.description   = "Basic tools for Heroku Vault's Ruby projects"
   gem.summary       = "Test classes, base web classes, and helpers - oh my!"
   gem.homepage      = ""
-  gem.required_ruby_version = '>= 2.5.3'
+  gem.required_ruby_version = '>= 2.7.1'
 
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep('^(test|spec|features)/')


### PR DESCRIPTION
In this PR, the ruby version was upgraded to 2.7.1. This came with a lot of other small changes like the circle ci update, deprecated ways of writing code was updated, etc. Guard-minitest was deprecated so I removed it from the project. Everything ran normally locally.