### PR TITLE
Adds support for metadata tags on request status metrics

### DIFF
--- a/lib/vault-tools/web.rb
+++ b/lib/vault-tools/web.rb
@@ -112,7 +112,8 @@ module Vault
     # Log details about the request including how long it took.
     after do
       @action ||= 'unknown'
-      Log.count_status(response.status, request_path: request.path_info)
+      @metadata ||= {}
+      Log.count_status(response.status, @metadata.merge(request_path: request.path_info))
       Log.time("http.#{@action}", (Time.now - @start_request) * 1000)
     end
 

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -247,6 +247,18 @@ class WebTest < Vault::TestCase
     assert_equal request_id, last_response.headers['Request-ID']
   end
 
+  def test_that_metadata_gets_logged
+    mock(Vault::Log).count_status(200, {
+      'user' => 'amanda',
+      'some_flag' => 'true',
+      request_path:  '/logging-test'
+    })
+    app.get '/logging-test' do
+      @metadata = {'user' => 'amanda', 'some_flag' => 'true'}
+    end
+    get '/logging-test'
+  end
+
   def test_that_excon_proxies_request_id
     request_id = 'JKJK-123'
     Excon.stub(

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.description   = "Basic tools for Heroku Vault's Ruby projects"
   gem.summary       = "Test classes, base web classes, and helpers - oh my!"
   gem.homepage      = ""
-  gem.required_ruby_version = '>= 2.7.1'
+  gem.required_ruby_version = '>= 2.5.3'
 
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep('^(test|spec|features)/')


### PR DESCRIPTION
After this is pulled into vault-usage, we'll be able to set the reporter
username (or id) in `@metadata` and have it logged with the request path and
status code.

W-10278847