### PR TITLE
updates syntax + bumps rollbar gem version to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    vault-tools (2.1.1)
+    vault-tools (2.2.0)
       aws-sdk-s3 (~> 1.0)
       coderay
       excon
       fernet (= 2.0)
       rack (~> 2.0)
       rack-ssl-enforcer
-      rollbar (~> 2.18.2)
+      rollbar
       scrolls (~> 0.9)
       sinatra (~> 2.0.4)
       uuidtools
@@ -44,7 +44,6 @@ GEM
     minitest (5.14.4)
     minitest-around (0.5.0)
       minitest (~> 5.0)
-    multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nokogiri (1.12.3)
@@ -62,8 +61,7 @@ GEM
       rack (>= 1.0, < 3)
     rake (13.0.6)
     rdoc (6.3.2)
-    rollbar (2.18.2)
-      multi_json
+    rollbar (3.4.0)
     rr (1.2.1)
     ruby2_keywords (0.0.5)
     scrolls (0.9.1)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Generate the API documentation:
     > bundle exec rake release
 
 ## Release Notes
+  Version 2.2.0 (2023-09-18):
+    - Changes syntax for Rollbar helper
+    - Bumps rollbar gem version 
+    - Unpings rollbar gem version
   Version 2.1.1 (2022-01-06):
     - Added tooling to support metadata tags on request status metrics.
     - Reverted change to minimum supported ruby version.

--- a/lib/vault-tools/rollbar_helper.rb
+++ b/lib/vault-tools/rollbar_helper.rb
@@ -2,7 +2,7 @@
 module Rollbar
   # Store calls to notify in an array instead
   # of calling out to the Rollbar service
-  def self.notify(exception, opts = {})
-    Rollbar.error(exception, opts)
+  def self.notify(exception, **opts)
+    Rollbar.error(exception, **opts)
   end
 end

--- a/lib/vault-tools/version.rb
+++ b/lib/vault-tools/version.rb
@@ -2,6 +2,6 @@
 
 module Vault
   module Tools
-    VERSION = '2.1.1'
+    VERSION = '2.2.0'
   end
 end

--- a/vault-tools.gemspec
+++ b/vault-tools.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'uuidtools'
   gem.add_dependency 'rack-ssl-enforcer'
   gem.add_dependency 'fernet', '2.0'
-  gem.add_dependency 'rollbar', '~> 2.18.2'
+  gem.add_dependency 'rollbar'
   gem.add_dependency 'aws-sdk-s3', '~> 1.0'
   gem.add_dependency 'excon'
   gem.add_dependency 'rack', '~> 2.0'


### PR DESCRIPTION
When promoting a recent PR to bring vault-usage to a modern version of Ruby, the Rollbar started to throw an argument error. This is most likely due to syntax differences between versions of Ruby/outdated dependencies